### PR TITLE
Remove some Python 2 support artifacts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ Tested with all combinations of:
 * Python: 3.6
 * Django: 2.0, 2.1
 
+Python 3.4+ supported.
+
 Installation
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -14,10 +13,10 @@ def get_version(filename):
 version = get_version('django_feature_policy.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 setup(


### PR DESCRIPTION
This package never supported Python 2, but these were copied from anothre project used as a template

* In `setup.py`, remove use of `codecs.open`
* In `README.rst`, update to "Python 3.4+ supported."