### PR TITLE
Reduce the impact on every request

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending release
 .. Insert new release notes below this line
 
 * Fix interpretation of '*' by not automatically adding quotes.
+* Optimize header generation to reduce impact on every request.
 
 2.1.0 (2019-04-28)
 ------------------

--- a/django_feature_policy.py
+++ b/django_feature_policy.py
@@ -43,6 +43,7 @@ FEATURE_NAMES = {
 class FeaturePolicyMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
+        self.header_value  # Access at setup so ImproperlyConfigured can be raised
         receiver(setting_changed)(self.clear_header_value)
 
     def __call__(self, request):

--- a/django_feature_policy.py
+++ b/django_feature_policy.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 
 __version__ = '2.1.0'
 
 # Retrieved from Chrome document.featurePolicy.allowedFeatures()
-FEATURE_NAMES = [
+FEATURE_NAMES = {
     'accelerometer',
     'ambient-light-sensor',
     'autoplay',
@@ -34,19 +34,19 @@ FEATURE_NAMES = [
     'vertical-scroll',
     'vr',
     'wake-lock',
-]
+}
 
 
 class FeaturePolicyMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        self.get_header_value()  # to check
+        self.header_value = self.get_header_value()
+        if not self.header_value:
+            raise MiddlewareNotUsed()
 
     def __call__(self, request):
         response = self.get_response(request)
-        value = self.get_header_value()
-        if value:
-            response['Feature-Policy'] = value
+        response['Feature-Policy'] = self.header_value
         return response
 
     def get_header_value(self):

--- a/tests/test_django_feature_policy.py
+++ b/tests/test_django_feature_policy.py
@@ -81,3 +81,23 @@ def test_unknown_feature(client, settings):
 
     with pytest.raises(ImproperlyConfigured):
         client.get('/')
+
+
+def test_setting_changing(client, settings):
+    settings.FEATURE_POLICY = {}
+    client.get('/')  # Forces middleware instantiation
+    settings.FEATURE_POLICY = {'geolocation': 'self'}
+
+    resp = client.get('/')
+
+    assert resp['Feature-Policy'] == "geolocation 'self'"
+
+
+def test_other_setting_changing(client, settings):
+    settings.FEATURE_POLICY = {'geolocation': 'self'}
+    client.get('/')  # Forces middleware instantiation
+    settings.SECRET_KEY = 'foobar'
+
+    resp = client.get('/')
+
+    assert resp['Feature-Policy'] == "geolocation 'self'"


### PR DESCRIPTION
- Use a set for faster membership test
- Generate the header once at boot time
- Disable the middleware if no header need to be added

fixes https://github.com/adamchainz/django-feature-policy/issues/21