### PR TITLE
Fix testing on Django 1.11

### DIFF
--- a/requirements/py35-django111.txt
+++ b/requirements/py35-django111.txt
@@ -7,7 +7,7 @@
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 coverage==4.5.3           # via pytest-cov
-django==2.2.1
+django==1.11.20
 docutils==0.14
 entrypoints==0.3          # via flake8
 flake8-commas==2.0.0

--- a/requirements/py36-django111.txt
+++ b/requirements/py36-django111.txt
@@ -7,7 +7,7 @@
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 coverage==4.5.3           # via pytest-cov
-django==2.2.1
+django==1.11.20
 docutils==0.14
 entrypoints==0.3          # via flake8
 flake8-commas==2.0.0

--- a/requirements/py37-django111.txt
+++ b/requirements/py37-django111.txt
@@ -7,7 +7,7 @@
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 coverage==4.5.3           # via pytest-cov
-django==2.2.1
+django==1.11.20
 docutils==0.14
 entrypoints==0.3          # via flake8
 flake8-commas==2.0.0

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,7 +1,14 @@
-from django.urls import path
-
 from testapp.views import index
 
-urlpatterns = [
-    path('', index, name='index'),
-]
+try:
+    from django.urls import path
+
+    urlpatterns = [
+        path('', index, name='index'),
+    ]
+except ImportError:  # Django < 2.0
+    from django.conf.urls import url
+
+    urlpatterns = [
+        url(r"^$", index, name="index"),
+    ]


### PR DESCRIPTION
For some reason the django111 requirements files had Django 2.2 installed instead, so Django 1.11 was never actually tested! Luckily no changes are needed outside of the test suite.