### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ Set the draft security HTTP header ``Feature-Policy`` on your Django app.
 Requirements
 ------------
 
-Python 3.5-3.8 supported.
+Python 3.5 to 3.8 supported.
 
-Django 1.11-3.0 supported.
+Django 1.11 to 3.0 supported.
 
 Installation
 ------------


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.