### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - python: 3.8
   - python: 3.9-dev
 
-install: pip install tox-travis
+install: python -m pip install tox-travis
 
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Install with **pip**:
 
 .. code-block:: sh
 
-    pip install django-feature-policy
+    python -m pip install django-feature-policy
 
 Then add the middleware, best after Django's ``SecurityMiddleware`` as it does
 similar addition of security headers that you'll want on every response:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py38-codestyle
 
 [testenv]
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = python -Wd -m pytest {posargs}
 
 [testenv:py35-django111]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).