### PR TITLE
Support rename to Permissions-Policy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@ History
 
 * Drop Django 2.0 and 2.1 support.
 * Move license from ISC to MIT License.
+* Update for the rename of the header from ``Feature-Policy`` to
+  ``Permissions-Policy``. This means the middleware has been renamed to
+  ``PermissionsPolicyMiddleware`` and the setting has been renamed to
+  ``PERMISSIONS_POLICY``. The old names are supported as aliases for backwards
+  compatibility. The middleware also sets both the old and new names for
+  compatibility with older browsers.
 
 3.4.0 (2020-05-24)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ django-feature-policy
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/python/black
 
-Set the draft security HTTP header ``Feature-Policy`` on your Django app.
+Set the draft security HTTP header ``Permissions-Policy`` (previously ``Feature-Policy``) on your Django app.
 
 Requirements
 ------------
@@ -43,19 +43,30 @@ similar addition of security headers that you'll want on every response:
     MIDDLEWARE = [
       ...
       'django.middleware.security.SecurityMiddleware',
-      'django_feature_policy.FeaturePolicyMiddleware',
+      'django_feature_policy.PermissionsPolicyMiddleware',
       ...
     ]
 
-By default no header will be set, configure the setting as below.
+The middleware will set the ``Permissions-Policy`` header, and also set it with
+the previous name ``Feature-Policy``, for backwards compatibility with older
+browsers.
+
+The header will not be set until you configure the setting to set at least one
+policy, as below.
+
+(For backwards compatibility, the middleware is also importable from the alias
+``FeaturePolicyMiddleware``.)
 
 Setting
 -------
 
-Change the ``FEATURE_POLICY`` setting to configure what ``Feature-Policy``
-header gets set.
+Change the ``PERMISSIONS_POLICY`` setting to configure the contents of the
+header.
 
-This should be a dictionary laid out with:
+(For backwards compatibility, the ``FEATURE_POLICY`` setting will also be read
+if ``PERMISSIONS_POLICY`` is not defined.)
+
+The setting should be a dictionary laid out with:
 
 * Keys as the names of browser features - a full list is available on the
   `W3 Spec repository`_. The `MDN article`_ is also worth reading.

--- a/README.rst
+++ b/README.rst
@@ -71,13 +71,15 @@ The setting should be a dictionary laid out with:
 * Keys as the names of browser features - a full list is available on the
   `W3 Spec repository`_. The `MDN article`_ is also worth reading.
 * Values as lists of strings, where each string is either an origin, e.g.
-  ``'https://example.com'``, or of the special values ``'self'``, ``'none'``,
-  or ``'*'``. If there is just one value, no containing list is necessary. Note
-  that in the header, special values like ``'none'`` include single quotes
-  around them - do not include these quotes in your Python string, they will be
-  added by the middleware.
+  ``'https://example.com'``, or of the special values ``'self'`` or ``'*'``. If
+  there is just one value, no containing list is necessary. To represent no
+  origins being allowed, use an empty list.
 
-.. _W3 Spec repository: https://github.com/w3c/webappsec-feature-policy/blob/master/features.md
+  Note that in the header, domains are wrapped in double quotes - do not
+  include these quotes within your Python string, as they will be added by the
+  middleware.
+
+.. _W3 Spec repository: https://github.com/w3c/webappsec-permissions-policy/blob/master/features.md
 .. _MDN article: https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy#Browser_compatibility
 
 If the keys or values are invalid, ``ImproperlyConfigured`` will be raised at
@@ -85,22 +87,35 @@ instantiation time, or when processing a response. The current feature list is
 pulled from the JavaScript API with
 ``document.featurePolicy.allowedFeatures()`` on Chrome.
 
+For backwards compatibility with the old ``Feature-Policy`` header and
+configuration, the value ``'none'`` is supported in lists, but ignored - it's
+preferable to use the empty list instead. It doesn't make sense to specify
+``'none'`` alongside other values.
+
 Examples
 ~~~~~~~~
 
-Disable geolocation from running in the current page and any iframe:
+Disable geolocation entirely, for the current origin and any iframes:
 
 .. code-block:: python
 
-    FEATURE_POLICY = {
-        'geolocation': 'none',
+    PERMISSIONS_POLICY = {
+        "geolocation": [],
     }
 
-Allow autoplay from the current origin and iframes from
+Allow autoplay from only the current origin and iframes from
 ``https://archive.org``:
 
 .. code-block:: python
 
-    FEATURE_POLICY = {
-        'autoplay': ['self', 'https://archive.org'],
+    PERMISSIONS_POLICY = {
+        "autoplay": ["self", "https://archive.org"],
+    }
+
+Allow autoplay from all origins:
+
+.. code-block:: python
+
+    PERMISSIONS_POLICY = {
+        "autoplay": "*",
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = django-feature-policy
 version = 3.4.0
-description = Set the draft security HTTP header Feature-Policy on your Django app.
+description = Set the draft security HTTP header Permissions-Policy (previously Feature-Policy) on your Django app.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Adam Johnson

--- a/tests/test_django_feature_policy.py
+++ b/tests/test_django_feature_policy.py
@@ -1,6 +1,8 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
+import django_feature_policy
+
 
 def test_index(client):
     resp = client.get("/")
@@ -12,59 +14,86 @@ def test_index(client):
 def test_no_setting(client):
     resp = client.get("/")
 
+    assert "Permissions-Policy" not in resp
+    assert "Feature-Policy" not in resp
+
+
+def test_empty_setting(client, settings):
+    settings.PERMISSIONS_POLICY = {}
+    resp = client.get("/")
+
+    assert "Permissions-Policy" not in resp
+    assert "Feature-Policy" not in resp
+
+
+def test_empty_setting_old_alias(client, settings):
+    settings.FEATURE_POLICY = {}
+    resp = client.get("/")
+
+    assert "Permissions-Policy" not in resp
     assert "Feature-Policy" not in resp
 
 
 def test_anyone_can_geolocate(client, settings):
+    settings.PERMISSIONS_POLICY = {"geolocation": "*"}
+
+    resp = client.get("/")
+
+    assert resp["Permissions-Policy"] == "geolocation *"
+    assert resp["Feature-Policy"] == "geolocation *"
+
+
+def test_anyone_can_geolocate_old_alias(client, settings):
     settings.FEATURE_POLICY = {"geolocation": "*"}
 
     resp = client.get("/")
 
+    assert resp["Permissions-Policy"] == "geolocation *"
     assert resp["Feature-Policy"] == "geolocation *"
 
 
 def test_anyone_can_geolocate_list(client, settings):
-    settings.FEATURE_POLICY = {"geolocation": ["*"]}
+    settings.PERMISSIONS_POLICY = {"geolocation": ["*"]}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation *"
+    assert resp["Permissions-Policy"] == "geolocation *"
 
 
 def test_no_one_can_geolocate(client, settings):
-    settings.FEATURE_POLICY = {"geolocation": "none"}
+    settings.PERMISSIONS_POLICY = {"geolocation": "none"}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation 'none'"
+    assert resp["Permissions-Policy"] == "geolocation 'none'"
 
 
 def test_self_can_geolocate(client, settings):
-    settings.FEATURE_POLICY = {"geolocation": "self"}
+    settings.PERMISSIONS_POLICY = {"geolocation": "self"}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation 'self'"
 
 
 def test_example_com_can_geolocate(client, settings):
-    settings.FEATURE_POLICY = {"geolocation": "https://example.com"}
+    settings.PERMISSIONS_POLICY = {"geolocation": "https://example.com"}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation https://example.com"
+    assert resp["Permissions-Policy"] == "geolocation https://example.com"
 
 
 def test_multiple_allowed(client, settings):
-    settings.FEATURE_POLICY = {"autoplay": ["self", "https://example.com"]}
+    settings.PERMISSIONS_POLICY = {"autoplay": ["self", "https://example.com"]}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "autoplay 'self' https://example.com"
+    assert resp["Permissions-Policy"] == "autoplay 'self' https://example.com"
 
 
 def test_multiple_features(client, settings):
-    settings.FEATURE_POLICY = {
+    settings.PERMISSIONS_POLICY = {
         "accelerometer": "self",
         "geolocation": ["self", "https://example.com"],
     }
@@ -72,33 +101,50 @@ def test_multiple_features(client, settings):
     resp = client.get("/")
 
     assert (
-        resp["Feature-Policy"]
+        resp["Permissions-Policy"]
         == "accelerometer 'self'; geolocation 'self' https://example.com"
     )
 
 
 def test_unknown_feature(client, settings):
-    settings.FEATURE_POLICY = {"accelerometor": "self"}
+    settings.PERMISSIONS_POLICY = {"accelerometor": "self"}
 
     with pytest.raises(ImproperlyConfigured):
         client.get("/")
 
 
 def test_setting_changing(client, settings):
+    settings.PERMISSIONS_POLICY = {}
+    client.get("/")  # Forces middleware instantiation
+    settings.PERMISSIONS_POLICY = {"geolocation": "self"}
+
+    resp = client.get("/")
+
+    assert resp["Permissions-Policy"] == "geolocation 'self'"
+
+
+def test_setting_changing_old_alias(client, settings):
     settings.FEATURE_POLICY = {}
     client.get("/")  # Forces middleware instantiation
     settings.FEATURE_POLICY = {"geolocation": "self"}
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation 'self'"
 
 
 def test_other_setting_changing(client, settings):
-    settings.FEATURE_POLICY = {"geolocation": "self"}
+    settings.PERMISSIONS_POLICY = {"geolocation": "self"}
     client.get("/")  # Forces middleware instantiation
     settings.SECRET_KEY = "foobar"
 
     resp = client.get("/")
 
-    assert resp["Feature-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation 'self'"
+
+
+def test_middleware_alias():
+    assert (
+        django_feature_policy.FeaturePolicyMiddleware
+        is django_feature_policy.PermissionsPolicyMiddleware
+    )

--- a/tests/test_django_feature_policy.py
+++ b/tests/test_django_feature_policy.py
@@ -39,7 +39,7 @@ def test_anyone_can_geolocate(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation *"
+    assert resp["Permissions-Policy"] == "geolocation=(*)"
     assert resp["Feature-Policy"] == "geolocation *"
 
 
@@ -48,7 +48,7 @@ def test_anyone_can_geolocate_old_alias(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation *"
+    assert resp["Permissions-Policy"] == "geolocation=(*)"
     assert resp["Feature-Policy"] == "geolocation *"
 
 
@@ -57,15 +57,26 @@ def test_anyone_can_geolocate_list(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation *"
+    assert resp["Permissions-Policy"] == "geolocation=(*)"
+    assert resp["Feature-Policy"] == "geolocation *"
 
 
 def test_no_one_can_geolocate(client, settings):
+    settings.PERMISSIONS_POLICY = {"geolocation": []}
+
+    resp = client.get("/")
+
+    assert resp["Permissions-Policy"] == "geolocation=()"
+    assert resp["Feature-Policy"] == "geolocation 'none'"
+
+
+def test_no_one_can_geolocate_old_none_value(client, settings):
     settings.PERMISSIONS_POLICY = {"geolocation": "none"}
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation 'none'"
+    assert resp["Permissions-Policy"] == "geolocation=()"
+    assert resp["Feature-Policy"] == "geolocation 'none'"
 
 
 def test_self_can_geolocate(client, settings):
@@ -73,7 +84,8 @@ def test_self_can_geolocate(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation=(self)"
+    assert resp["Feature-Policy"] == "geolocation 'self'"
 
 
 def test_example_com_can_geolocate(client, settings):
@@ -81,7 +93,8 @@ def test_example_com_can_geolocate(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation https://example.com"
+    assert resp["Permissions-Policy"] == 'geolocation=("https://example.com")'
+    assert resp["Feature-Policy"] == "geolocation https://example.com"
 
 
 def test_multiple_allowed(client, settings):
@@ -89,7 +102,8 @@ def test_multiple_allowed(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "autoplay 'self' https://example.com"
+    assert resp["Permissions-Policy"] == 'autoplay=(self "https://example.com")'
+    assert resp["Feature-Policy"] == "autoplay 'self' https://example.com"
 
 
 def test_multiple_features(client, settings):
@@ -102,6 +116,10 @@ def test_multiple_features(client, settings):
 
     assert (
         resp["Permissions-Policy"]
+        == 'accelerometer=(self), geolocation=(self "https://example.com")'
+    )
+    assert (
+        resp["Feature-Policy"]
         == "accelerometer 'self'; geolocation 'self' https://example.com"
     )
 
@@ -120,7 +138,8 @@ def test_setting_changing(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation=(self)"
+    assert resp["Feature-Policy"] == "geolocation 'self'"
 
 
 def test_setting_changing_old_alias(client, settings):
@@ -130,7 +149,8 @@ def test_setting_changing_old_alias(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation=(self)"
+    assert resp["Feature-Policy"] == "geolocation 'self'"
 
 
 def test_other_setting_changing(client, settings):
@@ -140,7 +160,8 @@ def test_other_setting_changing(client, settings):
 
     resp = client.get("/")
 
-    assert resp["Permissions-Policy"] == "geolocation 'self'"
+    assert resp["Permissions-Policy"] == "geolocation=(self)"
+    assert resp["Feature-Policy"] == "geolocation 'self'"
 
 
 def test_middleware_alias():


### PR DESCRIPTION
Fixes #114.

To do:
- [x] Use the new syntax in the new header name